### PR TITLE
feat: add support for deleting emojis

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,24 @@
+const config = {
+    channel: "C02T3CU03T3",
+    reqHeaders: {
+        "User-Agent":
+            "Mozilla/5.0 (Windows NT 11.0; WOW64; x64; rv:93.0esr) Gecko/20010101 Firefox/93.0esr/Yp6557blmseFJz",
+        Accept: "*/*",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-site",
+        "Sec-GPC": "1",
+        Pragma: "no-cache",
+        "Cache-Control": "no-cache",
+        Cookie: process.env.SLACK_COOKIE,
+        TE: "trailers",
+        Origin: "https://app.slack.com",
+        Host: "hackclub.slack.com",
+        DNT: "1",
+        Connection: "keep-alive",
+    },
+    admins: ["U01FGQ5V9L5"],
+};
+
+export default config;

--- a/src/features/deleteHandler.ts
+++ b/src/features/deleteHandler.ts
@@ -1,0 +1,50 @@
+import * as FormData from "form-data";
+import { App } from "@slack/bolt";
+import fetch from "node-fetch";
+import config from "../config";
+
+async function deleteEmoji(emojiName: string, user: string) {
+    const form = new FormData();
+    form.append("_x_reason", "customize-emoji-remove");
+    form.append("_x_mode", "online");
+    form.append("name", emojiName);
+    form.append("token", process.env.SLACK_BOT_USER_TOKEN);
+    const res = await fetch(
+        "https://hackclub.slack.com/api/emoji.remove?_x_id=9791fced-1647058806.077&slack_route=T0266FRGM&_x_version_ts=no-version&fp=a3",
+        {
+            method: "POST",
+            headers: {
+                ...config.reqHeaders,
+                "Content-Length": form.getLengthSync().toString(),
+                ...form.getHeaders(),
+            },
+            body: form.getBuffer(),
+        }
+    ).then((res) => res.json() as Promise<{ ok: boolean }>);
+    return res.ok
+        ? `:${emojiName}: has been removed, thanks <@${user}>!`
+        : `Failed to remove emoji:
+\`\`\`
+${JSON.stringify(res, null, 4)}
+\`\`\``;
+}
+
+const feature3 = async (app: App) => {
+    app.view("delete_view", async ({ client, ack, view }) => {
+        await ack();
+        console.log("sususususssdfdssf");
+        const meta = JSON.parse(view.private_metadata) as {
+            emoji: string;
+            thread_ts: string;
+            user: string;
+        };
+        const status = await deleteEmoji(meta.emoji, meta.user);
+        await client.chat.postMessage({
+            channel: config.channel,
+            thread_ts: meta.thread_ts,
+            text: status,
+        });
+    });
+};
+
+export default feature3;

--- a/src/features/deleteHandler.ts
+++ b/src/features/deleteHandler.ts
@@ -9,18 +9,15 @@ async function deleteEmoji(emojiName: string, user: string) {
     form.append("_x_mode", "online");
     form.append("name", emojiName);
     form.append("token", process.env.SLACK_BOT_USER_TOKEN);
-    const res = await fetch(
-        "https://hackclub.slack.com/api/emoji.remove",
-        {
-            method: "POST",
-            headers: {
-                ...config.reqHeaders,
-                "Content-Length": form.getLengthSync().toString(),
-                ...form.getHeaders(),
-            },
-            body: form.getBuffer(),
-        }
-    ).then((res) => res.json() as Promise<{ ok: boolean }>);
+    const res = await fetch("https://hackclub.slack.com/api/emoji.remove", {
+        method: "POST",
+        headers: {
+            ...config.reqHeaders,
+            "Content-Length": form.getLengthSync().toString(),
+            ...form.getHeaders(),
+        },
+        body: form.getBuffer(),
+    }).then((res) => res.json() as Promise<{ ok: boolean }>);
     return res.ok
         ? `:${emojiName}: has been removed, thanks <@${user}>!`
         : `Failed to remove emoji:
@@ -32,7 +29,6 @@ ${JSON.stringify(res, null, 4)}
 const feature3 = async (app: App) => {
     app.view("delete_view", async ({ client, ack, view }) => {
         await ack();
-        console.log("sususususssdfdssf");
         const meta = JSON.parse(view.private_metadata) as {
             emoji: string;
             thread_ts: string;

--- a/src/features/deleteHandler.ts
+++ b/src/features/deleteHandler.ts
@@ -10,7 +10,7 @@ async function deleteEmoji(emojiName: string, user: string) {
     form.append("name", emojiName);
     form.append("token", process.env.SLACK_BOT_USER_TOKEN);
     const res = await fetch(
-        "https://hackclub.slack.com/api/emoji.remove?_x_id=9791fced-1647058806.077&slack_route=T0266FRGM&_x_version_ts=no-version&fp=a3",
+        "https://hackclub.slack.com/api/emoji.remove",
         {
             method: "POST",
             headers: {

--- a/src/features/deleteModal.ts
+++ b/src/features/deleteModal.ts
@@ -1,0 +1,114 @@
+import { App, View } from "@slack/bolt";
+import config from "../config";
+
+function deleteView(emoji: string, thread_ts: string, user: string): View {
+    return {
+        callback_id: "delete_view",
+        type: "modal",
+        title: {
+            type: "plain_text",
+            text: "Confirm Deletion",
+        },
+        submit: {
+            type: "plain_text",
+            text: "Confirm",
+            emoji: true,
+        },
+        close: {
+            type: "plain_text",
+            text: "Cancel",
+            emoji: true,
+        },
+        private_metadata: JSON.stringify({ emoji, thread_ts, user }),
+        blocks: [
+            {
+                type: "context",
+                elements: [
+                    {
+                        type: "plain_text",
+                        text: `Delete :${emoji}:?`,
+                        emoji: true,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function errorView(reason: string): View {
+    return {
+        type: "modal",
+        title: {
+            type: "plain_text",
+            text: "Error",
+            emoji: true,
+        },
+        close: {
+            type: "plain_text",
+            text: "Okay",
+            emoji: true,
+        },
+        blocks: [
+            {
+                type: "context",
+                elements: [
+                    {
+                        type: "plain_text",
+                        text: reason,
+                        emoji: true,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+const feature2 = async (app: App) => {
+    app.shortcut(
+        { callback_id: "delete_emoji", type: "message_action" },
+        async ({ shortcut, ack, client }) => {
+            await ack();
+            console.log(shortcut);
+
+            if (shortcut.channel.id !== config.channel) {
+                await client.views.open({
+                    trigger_id: shortcut.trigger_id,
+                    view: errorView(
+                        "This channel doesn't have any emojis managed by emojibot."
+                    ),
+                });
+                return;
+            }
+
+            if (
+                shortcut.user.id !== shortcut.message.user ||
+                config.admins.includes(shortcut.user.id)
+            ) {
+                await client.views.open({
+                    trigger_id: shortcut.trigger_id,
+                    view: errorView(
+                        "Only the OP or authorized admins can delete emojis added with emojibot."
+                    ),
+                });
+                return;
+            }
+
+            const emojiName =
+                shortcut.message.text.startsWith(":") &&
+                shortcut.message.text.endsWith(":")
+                    ? shortcut.message.text.slice(1, -1)
+                    : shortcut.message.text;
+
+            await client.views.open({
+                trigger_id: shortcut.trigger_id,
+                view: deleteView(
+                    emojiName,
+                    shortcut.message_ts,
+                    shortcut.user.id
+                ),
+            });
+        }
+    );
+};
+
+export default feature2;

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,5 @@
 // This is where you should export all the features. Every folder in the starter kit follows this spec.
 
 export { default as uploader } from "./uploader";
+export { default as deleteModal } from "./deleteModal";
+export { default as deleteHandler } from "./deleteHandler";

--- a/src/features/uploader.ts
+++ b/src/features/uploader.ts
@@ -1,12 +1,12 @@
 import { App } from "@slack/bolt";
 import fetch from "node-fetch";
 import * as FormData from "form-data";
-
+import config from "../config";
 const feature1 = async (app: App) => {
     app.message("", async ({ message, say }) => {
         if (
             message.subtype !== "file_share" ||
-            message.channel !== "C02T3CU03T3"
+            message.channel !== config.channel
         )
             // only listen for messages in #emojibot
             return;
@@ -43,31 +43,16 @@ const feature1 = async (app: App) => {
 
         // No idea how much of this is necessary but I don't feel like figuring it out
         const res = await fetch("https://hackclub.slack.com/api/emoji.add", {
-            credentials: "include",
+            // credentials: "include",
             method: "POST",
-            mode: "cors",
+            // mode: "cors",
             headers: {
-                "User-Agent":
-                    "Mozilla/5.0 (Windows NT 11.0; WOW64; x64; rv:93.0esr) Gecko/20010101 Firefox/93.0esr/Yp6557blmseFJz",
-                Accept: "*/*",
-                "Accept-Language": "en-US,en;q=0.5",
-                "Sec-Fetch-Dest": "empty",
-                "Sec-Fetch-Mode": "cors",
-                "Sec-Fetch-Site": "same-site",
-                "Sec-GPC": "1",
-                Pragma: "no-cache",
-                "Cache-Control": "no-cache",
-                Cookie: process.env.SLACK_COOKIE,
-                TE: "trailers",
-                Origin: "https://app.slack.com",
-                Host: "hackclub.slack.com",
-                DNT: "1",
-                Connection: "keep-alive",
+                ...config.reqHeaders,
                 "Content-Length": form.getLengthSync().toString(),
                 ...form.getHeaders(),
             },
             body: form.getBuffer(),
-        }).then((res) => res.json());
+        }).then((res) => res.json() as Promise<{ ok: boolean }>);
         say({
             text: res.ok
                 ? `:${emojiName}: has been added, thanks <@${message.user}>!`


### PR DESCRIPTION
This PR:
- adds a shortcut that can be used to delete emojis
  - The OP of an emoji or designated admins (see line 26 on `src/config.ts`) can delete emojis with the shortcut
- moves some constants into a config file

You'll need to create a new shortcut with the callback ID `delete_emoji`. Name and description shouldn't matter, but the name I used in dev was `Delete Emoji` and the description was `Delete emojis added with emojibot`.